### PR TITLE
Update setup.py, exclude tests from install at top level

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     author="LennP",
     author_email="lennperik@hotmail.nl",
     license="MIT",
-    packages=find_packages(),
+    packages=find_packages(exclude=["tests*"]),
     python_requires=">=3.9",
     install_requires=[
         "bleak",


### PR DESCRIPTION
otherwise:

```
>>> Install dev-python/motionblindsble-0.0.9 into /var/tmp/portage/dev-python/motionblindsble-0.0.9/image
 * python3_11: running distutils-r1_run_phase distutils-r1_python_install
 * The following unexpected files/directories were found top-level
 * in the site-packages directory:
 *
 *   /usr/lib/python3.11/site-packages/tests
 *
 * This is most likely a bug in the build system.  More information
 * can be found in the Python Guide:
 * https://projects.gentoo.org/python/guide/qawarn.html#stray-top-level-files-in-site-packages
 * ERROR: dev-python/motionblindsble-0.0.9::HomeAssistantRepository failed (install phase):
 *   Failing install because of stray top-level files in site-packages
 *
 * Call stack:
 *     ebuild.sh, line  136:  Called src_install
 *   environment, line 4004:  Called distutils-r1_src_install
 *   environment, line 1939:  Called _distutils-r1_run_foreach_impl 'distutils-r1_python_install'
 *   environment, line  732:  Called python_foreach_impl 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line 3616:  Called multibuild_foreach_variant '_python_multibuild_wrapper' 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line 3114:  Called _multibuild_run '_python_multibuild_wrapper' 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line 3112:  Called _python_multibuild_wrapper 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line 1229:  Called distutils-r1_run_phase 'distutils-r1_python_install'
 *   environment, line 1902:  Called _distutils-r1_post_python_install
 *   environment, line  624:  Called die
 * The specific snippet of code:
 *               die "Failing install because of stray top-level files in site-packages";
 *
 * If you need support, post the output of `emerge --info '=dev-python/motionblindsble-0.0.9::HomeAssistantRepository'`,
 * the complete build log and the output of `emerge -pqv '=dev-python/motionblindsble-0.0.9::HomeAssistantRepository'`.
 * The complete build log is located at '/var/tmp/portage/dev-python/motionblindsble-0.0.9/temp/build.log'.
 * The ebuild environment file is located at '/var/tmp/portage/dev-python/motionblindsble-0.0.9/temp/environment'.
 * Working directory: '/var/tmp/portage/dev-python/motionblindsble-0.0.9/work/motionblindsble-0.0.9'
 * S: '/var/tmp/portage/dev-python/motionblindsble-0.0.9/work/motionblindsble-0.0.9'

 * Messages for package dev-python/motionblindsble-0.0.9:

 * The following unexpected files/directories were found top-level
 * in the site-packages directory:
 *
 *   /usr/lib/python3.11/site-packages/tests
 *
```