### PR TITLE
Fix/status query retry 153218

### DIFF
--- a/motionblindsble/const.py
+++ b/motionblindsble/const.py
@@ -9,6 +9,12 @@ SETTING_CALIBRATION_DISCONNECT_TIME = 45  # Seconds
 SETTING_NOTIFICATION_DELAY = 0.5  # Seconds
 SETTING_CONNECTION_DELAY = 0.2  # Seconds
 SETTING_DISABLE_CONNECT_STATUS_CALLBACK_TIME = 2  # Seconds
+# Number of times the status query is retried after connecting if the motor
+# does not respond with a status notification, and how long to wait for each.
+SETTING_MAX_STATUS_QUERY_ATTEMPTS = 3
+SETTING_STATUS_QUERY_TIMEOUT = 3  # Seconds
+# Upper bound for a command waiting on end position info (safety net).
+SETTING_END_POSITION_INFO_TIMEOUT = 15  # Seconds
 
 DISPLAY_NAME = "Motionblind {mac_code}"
 

--- a/motionblindsble/const.py
+++ b/motionblindsble/const.py
@@ -9,12 +9,8 @@ SETTING_CALIBRATION_DISCONNECT_TIME = 45  # Seconds
 SETTING_NOTIFICATION_DELAY = 0.5  # Seconds
 SETTING_CONNECTION_DELAY = 0.2  # Seconds
 SETTING_DISABLE_CONNECT_STATUS_CALLBACK_TIME = 2  # Seconds
-# Number of times the status query is retried after connecting if the motor
-# does not respond with a status notification, and how long to wait for each.
 SETTING_MAX_STATUS_QUERY_ATTEMPTS = 3
 SETTING_STATUS_QUERY_TIMEOUT = 3  # Seconds
-# Upper bound for a command waiting on end position info (safety net).
-SETTING_END_POSITION_INFO_TIMEOUT = 15  # Seconds
 
 DISPLAY_NAME = "Motionblind {mac_code}"
 

--- a/motionblindsble/device.py
+++ b/motionblindsble/device.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from asyncio import (
     FIRST_COMPLETED,
@@ -13,6 +14,7 @@ from asyncio import (
     get_event_loop,
     sleep,
     wait,
+    wait_for,
 )
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
@@ -41,9 +43,12 @@ from .const import (
     SETTING_CONNECTION_DELAY,
     SETTING_DISABLE_CONNECT_STATUS_CALLBACK_TIME,
     SETTING_DISCONNECT_TIME,
+    SETTING_END_POSITION_INFO_TIMEOUT,
     SETTING_MAX_COMMAND_ATTEMPTS,
     SETTING_MAX_CONNECT_ATTEMPTS,
+    SETTING_MAX_STATUS_QUERY_ATTEMPTS,
     SETTING_NOTIFICATION_DELAY,
+    SETTING_STATUS_QUERY_TIMEOUT,
     MotionBlindType,
     MotionCalibrationType,
     MotionCallback,
@@ -105,8 +110,22 @@ def requires_end_positions(
         async def wrapper(self: MotionDevice, *args, **kwargs):
             # pylint: disable=protected-access
             if self._end_position_info is None:
-                # Wait for end position info to be set by notification
-                await self._received_end_position_info_event.wait()
+                # Wait for end position info to be set by notification.
+                # Bounded so a missing status notification cannot block the
+                # command forever (see HA core issue #153218).
+                try:
+                    await wait_for(
+                        self._received_end_position_info_event.wait(),
+                        timeout=SETTING_END_POSITION_INFO_TIMEOUT,
+                    )
+                except asyncio.TimeoutError:
+                    _LOGGER.error(
+                        "(%s) Did not receive status notification, "
+                        "aborting command",
+                        self.ble_device.address,
+                    )
+                    self.update_running(MotionRunningType.STILL)
+                    return False
 
             if self.blind_type is MotionBlindType.CURTAIN:
                 # Curtain blinds can auto-calibrate and find end positions
@@ -693,17 +712,44 @@ class MotionDevice:
         # Used to initialize
         await self.set_key()
 
-        if self.blind_type in [
-            MotionBlindType.CURTAIN,
-            MotionBlindType.VERTICAL,
-        ]:
-            await sleep(SETTING_NOTIFICATION_DELAY)
+        # Give the motor a moment to process the set_key command before
+        # querying status. Previously this was only done for CURTAIN/VERTICAL
+        # blinds; doing it for all blind types reduces how often the first
+        # status query is dropped (see HA core issue #153218).
+        await sleep(SETTING_NOTIFICATION_DELAY)
 
         # Set the point (used after calibrating Curtain)
         # await self.point_set_query()
 
+        # Query status and wait for the motor's status notification, retrying
+        # if it is not received. The notification sets
+        # _received_end_position_info_event via update_status(). Without a
+        # retry, a dropped status query leaves the connection without end
+        # position info and any command will hang (see HA core issue #153218).
         self._connect_status_query_time = time_ns()
-        await self.status_query()
+        self._received_end_position_info_event.clear()
+        for attempt in range(SETTING_MAX_STATUS_QUERY_ATTEMPTS):
+            await self.status_query()
+            try:
+                await wait_for(
+                    self._received_end_position_info_event.wait(),
+                    timeout=SETTING_STATUS_QUERY_TIMEOUT,
+                )
+                break
+            except asyncio.TimeoutError:
+                _LOGGER.warning(
+                    "(%s) No status notification (attempt #%i), "
+                    "retrying status query",
+                    self.ble_device.address,
+                    attempt,
+                )
+        else:
+            _LOGGER.error(
+                "(%s) Did not receive status after connecting, disconnecting",
+                self.ble_device.address,
+            )
+            await self.disconnect()
+            return False
 
         self.refresh_disconnect_timer()
 

--- a/motionblindsble/device.py
+++ b/motionblindsble/device.py
@@ -43,7 +43,6 @@ from .const import (
     SETTING_CONNECTION_DELAY,
     SETTING_DISABLE_CONNECT_STATUS_CALLBACK_TIME,
     SETTING_DISCONNECT_TIME,
-    SETTING_END_POSITION_INFO_TIMEOUT,
     SETTING_MAX_COMMAND_ATTEMPTS,
     SETTING_MAX_CONNECT_ATTEMPTS,
     SETTING_MAX_STATUS_QUERY_ATTEMPTS,
@@ -110,18 +109,29 @@ def requires_end_positions(
         async def wrapper(self: MotionDevice, *args, **kwargs):
             # pylint: disable=protected-access
             if self._end_position_info is None:
-                # Wait for end position info to be set by notification.
-                # Bounded so a missing status notification cannot block the
-                # command forever (see HA core issue #153218).
-                try:
-                    await wait_for(
-                        self._received_end_position_info_event.wait(),
-                        timeout=SETTING_END_POSITION_INFO_TIMEOUT,
-                    )
-                except asyncio.TimeoutError:
+                # Wait for end position info to be set by notification,
+                # retrying the status query if the motor does not respond
+                # to it (see HA core issue #153218)
+                for attempt in range(SETTING_MAX_STATUS_QUERY_ATTEMPTS):
+                    if attempt > 0:
+                        await self.status_query()
+                    try:
+                        await wait_for(
+                            self._received_end_position_info_event.wait(),
+                            timeout=SETTING_STATUS_QUERY_TIMEOUT,
+                        )
+                        break
+                    except asyncio.TimeoutError:
+                        _LOGGER.warning(
+                            "(%s) Status notification not received"
+                            " (attempt #%i)",
+                            self.ble_device.address,
+                            attempt + 1,
+                        )
+                else:
                     _LOGGER.error(
-                        "(%s) Did not receive status notification, "
-                        "aborting command",
+                        "(%s) Did not receive end position info,"
+                        " aborting command",
                         self.ble_device.address,
                     )
                     self.update_running(MotionRunningType.STILL)
@@ -712,44 +722,17 @@ class MotionDevice:
         # Used to initialize
         await self.set_key()
 
-        # Give the motor a moment to process the set_key command before
-        # querying status. Previously this was only done for CURTAIN/VERTICAL
-        # blinds; doing it for all blind types reduces how often the first
-        # status query is dropped (see HA core issue #153218).
-        await sleep(SETTING_NOTIFICATION_DELAY)
+        if self.blind_type in [
+            MotionBlindType.CURTAIN,
+            MotionBlindType.VERTICAL,
+        ]:
+            await sleep(SETTING_NOTIFICATION_DELAY)
 
         # Set the point (used after calibrating Curtain)
         # await self.point_set_query()
 
-        # Query status and wait for the motor's status notification, retrying
-        # if it is not received. The notification sets
-        # _received_end_position_info_event via update_status(). Without a
-        # retry, a dropped status query leaves the connection without end
-        # position info and any command will hang (see HA core issue #153218).
         self._connect_status_query_time = time_ns()
-        self._received_end_position_info_event.clear()
-        for attempt in range(SETTING_MAX_STATUS_QUERY_ATTEMPTS):
-            await self.status_query()
-            try:
-                await wait_for(
-                    self._received_end_position_info_event.wait(),
-                    timeout=SETTING_STATUS_QUERY_TIMEOUT,
-                )
-                break
-            except asyncio.TimeoutError:
-                _LOGGER.warning(
-                    "(%s) No status notification (attempt #%i), "
-                    "retrying status query",
-                    self.ble_device.address,
-                    attempt,
-                )
-        else:
-            _LOGGER.error(
-                "(%s) Did not receive status after connecting, disconnecting",
-                self.ble_device.address,
-            )
-            await self.disconnect()
-            return False
+        await self.status_query()
 
         self.refresh_disconnect_timer()
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -116,6 +116,44 @@ class TestDeviceDecorators:
         )
 
     @patch(
+        "motionblindsble.device.MotionDevice.status_query",
+        AsyncMock(return_value=True),
+    )
+    async def test_requires_end_positions_retries_status_query(self) -> None:
+        """Test the @requires_end_positions decorator retrying the status
+        query if the status notification is not received."""
+        device = MotionDevice("00:11:22:33:44:55")
+        # Replace the event so the mocked wait_for does not leave an
+        # un-awaited Event.wait() coroutine behind
+        device._received_end_position_info_event = Mock()
+
+        @requires_end_positions
+        async def mock_method(self):
+            return True
+
+        # Test status notification received after one retry
+        with patch(
+            "motionblindsble.device.wait_for",
+            AsyncMock(side_effect=[asyncio.TimeoutError, None]),
+        ):
+            assert await mock_method(device)
+        # pylint: disable=no-member
+        assert device.status_query.call_count == 1
+
+        # Test command aborts if no status notification is ever received
+        device.status_query.reset_mock()
+        with patch(
+            "motionblindsble.device.wait_for",
+            AsyncMock(side_effect=asyncio.TimeoutError),
+        ):
+            assert not await mock_method(device)
+        assert (
+            device.status_query.call_count
+            == SETTING_MAX_STATUS_QUERY_ATTEMPTS - 1
+        )
+        assert device._running_type is MotionRunningType.STILL
+
+    @patch(
         "motionblindsble.device.MotionDevice.refresh_disconnect_timer",
         Mock(),
     )
@@ -286,10 +324,6 @@ class TestDeviceConnection:
     ) -> None:
         """Test the establish_connection function."""
         device = MotionDevice("00:11:22:33:44:55")
-        # Simulate the status notification arriving so the status query wait
-        # resolves immediately.
-        device._received_end_position_info_event = Mock()
-        device._received_end_position_info_event.wait = AsyncMock()
 
         # Test establish normal connection
         await device.establish_connection()
@@ -331,49 +365,6 @@ class TestDeviceConnection:
             device.blind_type = blind_type
             await device.establish_connection()
             mock_sleep.assert_has_calls([call(SETTING_CONNECTION_DELAY)])
-
-    @patch(
-        "motionblindsble.device.MotionDevice.refresh_disconnect_timer",
-        Mock(),
-    )
-    @patch(
-        "motionblindsble.device.MotionDevice.disconnect",
-        AsyncMock(),
-    )
-    @patch(
-        "motionblindsble.device.MotionDevice.status_query",
-        AsyncMock(return_value=True),
-    )
-    @patch(
-        "motionblindsble.device.MotionDevice._send_command",
-        AsyncMock(return_value=True),
-    )
-    @patch(
-        "motionblindsble.device.establish_connection",
-        AsyncMock(return_value=AsyncMock()),
-    )
-    @patch("motionblindsble.device.sleep", AsyncMock())
-    @patch(
-        "motionblindsble.device.wait_for",
-        AsyncMock(side_effect=asyncio.TimeoutError),
-    )
-    async def test_establish_connection_status_query_retry(self) -> None:
-        """Test that a missing status notification retries the status query
-        and then aborts the connection instead of hanging."""
-        device = MotionDevice("00:11:22:33:44:55")
-        device.blind_type = MotionBlindType.ROLLER
-        # Replace the event so the (mocked) wait_for never builds a real,
-        # un-awaited coroutine.
-        device._received_end_position_info_event = Mock()
-
-        result = await device.establish_connection()
-
-        # pylint: disable=no-member
-        assert result is False
-        assert (
-            device.status_query.call_count == SETTING_MAX_STATUS_QUERY_ATTEMPTS
-        )
-        device.disconnect.assert_awaited_once()
 
     @patch("motionblindsble.device.MotionDevice.is_connected")
     @patch("motionblindsble.device.ConnectionQueue.wait_for_connection")

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -12,6 +12,7 @@ from motionblindsble.device import (
     SETTING_CONNECTION_DELAY,
     SETTING_DISCONNECT_TIME,
     SETTING_MAX_COMMAND_ATTEMPTS,
+    SETTING_MAX_STATUS_QUERY_ATTEMPTS,
     SETTING_NOTIFICATION_DELAY,
     BleakError,
     BleakNotFoundError,
@@ -285,6 +286,10 @@ class TestDeviceConnection:
     ) -> None:
         """Test the establish_connection function."""
         device = MotionDevice("00:11:22:33:44:55")
+        # Simulate the status notification arriving so the status query wait
+        # resolves immediately.
+        device._received_end_position_info_event = Mock()
+        device._received_end_position_info_event.wait = AsyncMock()
 
         # Test establish normal connection
         await device.establish_connection()
@@ -326,6 +331,49 @@ class TestDeviceConnection:
             device.blind_type = blind_type
             await device.establish_connection()
             mock_sleep.assert_has_calls([call(SETTING_CONNECTION_DELAY)])
+
+    @patch(
+        "motionblindsble.device.MotionDevice.refresh_disconnect_timer",
+        Mock(),
+    )
+    @patch(
+        "motionblindsble.device.MotionDevice.disconnect",
+        AsyncMock(),
+    )
+    @patch(
+        "motionblindsble.device.MotionDevice.status_query",
+        AsyncMock(return_value=True),
+    )
+    @patch(
+        "motionblindsble.device.MotionDevice._send_command",
+        AsyncMock(return_value=True),
+    )
+    @patch(
+        "motionblindsble.device.establish_connection",
+        AsyncMock(return_value=AsyncMock()),
+    )
+    @patch("motionblindsble.device.sleep", AsyncMock())
+    @patch(
+        "motionblindsble.device.wait_for",
+        AsyncMock(side_effect=asyncio.TimeoutError),
+    )
+    async def test_establish_connection_status_query_retry(self) -> None:
+        """Test that a missing status notification retries the status query
+        and then aborts the connection instead of hanging."""
+        device = MotionDevice("00:11:22:33:44:55")
+        device.blind_type = MotionBlindType.ROLLER
+        # Replace the event so the (mocked) wait_for never builds a real,
+        # un-awaited coroutine.
+        device._received_end_position_info_event = Mock()
+
+        result = await device.establish_connection()
+
+        # pylint: disable=no-member
+        assert result is False
+        assert (
+            device.status_query.call_count == SETTING_MAX_STATUS_QUERY_ATTEMPTS
+        )
+        device.disconnect.assert_awaited_once()
 
     @patch("motionblindsble.device.MotionDevice.is_connected")
     @patch("motionblindsble.device.ConnectionQueue.wait_for_connection")


### PR DESCRIPTION
Addresses review comments on #4.


> Why not do the retries and timeout in the @requires_end_positions?

If the user connects but never triggers anything decorated with `@requires_end_positions`, and the motor never responds to the initial status query, the battery level and other status data stays unknown for the lifetime of that connection. This looks unintentional, since a status query is sent on connection to populate those fields. Instead, we could retry the status query in a background task on connect, rather than blocking `establish_connection` on it or waiting for a `@requires_end_positions` function to be called. For now, I've applied your recommendation.


